### PR TITLE
Mificando el gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,5 @@ venv.bak/
 .mypy_cache/
 
 # Others
-login/migrations
+*/migrations
 .vscode


### PR DESCRIPTION
Agregue las migraciones al gitignore de esta manera: `*/migrations` para que ignore todas las migraciones de todas las apps