### PR TITLE
Configuring simple jwt

### DIFF
--- a/backendProject/settings.py
+++ b/backendProject/settings.py
@@ -33,6 +33,8 @@ INSTALLED_APPS = [
     'rest_auth.registration',
     'django_filters',
     'corsheaders',
+    'rest_framework_simplejwt.token_blacklist',
+    
 
     'login',
 

--- a/backendProject/settings.py
+++ b/backendProject/settings.py
@@ -3,7 +3,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
+# * Importaciones necesarias
 import os
+from datetime import timedelta
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -135,10 +137,41 @@ REST_AUTH_REGISTER_SERIALIZERS = {
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
-       'rest_framework.permissions.AllowAny',
+       'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.DjangoFilterBackend',
-    ),
+    )
+}
 
+
+"""
+Configuraciones del token.
+Puedes encontrar la docuemtnacion en el README del proyecto simple_jwt
+https://github.com/davesque/django-rest-framework-simplejwt
+"""
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'ROTATE_REFRESH_TOKENS': False,
+    'BLACKLIST_AFTER_ROTATION': True,
+
+    'ALGORITHM': 'HS256',
+    'SIGNING_KEY': SECRET_KEY,
+    'VERIFYING_KEY': None,
+    'AUDIENCE': None,
+    'ISSUER': None,
+
+    'AUTH_HEADER_TYPES': ('Bearer',),
+    'USER_ID_FIELD': 'id',
+    'USER_ID_CLAIM': 'user_id',
+
+    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
+    'TOKEN_TYPE_CLAIM': 'token_type',
+
+    'JTI_CLAIM': 'jti',
+
+    'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
+    'SLIDING_TOKEN_LIFETIME': timedelta(minutes=5),
+    'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
 }

--- a/backendProject/urls.py
+++ b/backendProject/urls.py
@@ -2,12 +2,21 @@ from django.conf.urls import url, include
 from django.contrib import admin
 from django.urls import path
 from rest_framework_jwt.views import obtain_jwt_token
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    
+    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    
     #path('rest-auth/', include('rest_auth.urls')),
     #path('rest-auth/registration/', include('rest_auth.registration.urls')),
     path('', include('login.urls')),
+
     #path('api-token-auth/', obtain_jwt_token),
     #url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/login/views.py
+++ b/login/views.py
@@ -96,7 +96,7 @@ class Category_Viewset(ModelViewSet):
     """
 
     authentication_classes = [JWTTokenUserAuthentication]
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
     queryset           = Category.objects.all()

--- a/login/views.py
+++ b/login/views.py
@@ -2,7 +2,7 @@
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework import generics, status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny, IsAdminUser, IsAuthenticatedOrReadOnly
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
 

--- a/login/views.py
+++ b/login/views.py
@@ -5,6 +5,7 @@ from rest_framework import generics, status
 from rest_framework.permissions import IsAuthenticated, AllowAny, IsAdminUser, IsAuthenticatedOrReadOnly
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
+from rest_framework_simplejwt.authentication import JWTTokenUserAuthentication
 
 # Django
 from django.views.decorators.csrf import csrf_exempt
@@ -93,6 +94,11 @@ class Category_Viewset(ModelViewSet):
     """
     Proporciona un CRUD completo del modelo Category
     """
+
+    authentication_classes = [JWTTokenUserAuthentication]
+    permission_classes = [AllowAny]
+
+
     queryset           = Category.objects.all()
     serializer_class   = Category_Serializer
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ requests==2.21.0
 requests-oauthlib==1.2.0
 six==1.12.0
 urllib3==1.24.1
+djangorestframework-simplejwt==4.3.0


### PR DESCRIPTION
Instale la librería simple_jwt que es la recomendad de usar para los JSON Web Token Authentication según los desarrolladores de Dejango Rest Framewrok.

Fuente:
https://www.django-rest-framework.org/api-guide/authentication/#json-web-token-authentication