### PR TITLE
Desde la rama issue#4 gitignore a development 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,4 @@ venv.bak/
 .mypy_cache/
 
 # Others
-*/migrations
 .vscode


### PR DESCRIPTION
Se dejó de ignorar las migraciones ya que no hay que realizar tantos cambios al modelo a partir de ahora